### PR TITLE
Reduce logs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,10 +16,12 @@ are necessary for the build, but are not required at runtime. There may
 also be installable build dependencies that are not runtime
 dependencies.
 
-In our case, a complex front-end build involves significant CSS, JS and
-image assets, along with a large installation of node modules, all of
+Use cases include:
+
+* Large installation of node modules, all of
 which are used only for building the production assets, but then remain
 part of the slug.
+* Test and spec folders in Gem dependencies stored in vendor/bundle
 
 ## Usage
 
@@ -36,14 +38,11 @@ https://github.com/heroku/heroku-buildpack-ruby
 https://github.com/Lostmyname/heroku-post-build-clean-buildpack
 ```
 
-The `.slug-post-clean` file supports single-file and single-directory
-declarations only, e.g.:
+The `.slug-post-clean` file supports file globs (including file/directory names with whitespace, but NOT new lines) e.g.:
 
 ```
+vendor/bundle/ruby/*/gems/sass-*/test
 some_huge_file.psd
 some/nested/directory
 why_does_this_app_even_contain_a.tiff
 ```
-
-I might expand it to support file globs, but for the moment it's not
-necessary and the testing implications give me the willies.

--- a/bin/compile
+++ b/bin/compile
@@ -1,32 +1,79 @@
 #!/usr/bin/env bash
+#
+# Find and delete all files/directories matching specified globs
+# Globs are separated by newlines in .slug-post-clean located in the build directory's root
+# This is useful for deleting files created after Heroku's built-in cleanup process
+# based on .slugignore, e.g. files/dirs in installed dependency folders
 
 set -euo pipefail
 
-readonly BUILD_DIR=$1
-readonly CLEAN_FILES=.slug-post-clean
+readonly BUILDPACK_DIR=$(cd $(dirname $0); cd ..; pwd)
 
-if [[ ! -n "${BUILD_DIR}" ]]; then
-  echo "No build directory specified - exiting"
-  exit 1
-fi
+# Common helper functions
+source $BUILDPACK_DIR/bin/util/common.sh
+
+readonly CLEAN_FILES=.slug-post-clean
+readonly BUILD_DIR=$1
 
 cd ${BUILD_DIR}
 
-if [[ ! -f "${CLEAN_FILES}" ]]; then
-  echo "Could not find .slug-post-clean file - exiting"
-  exit 1
-fi
+#######################################
+# Locate files/dirs in PWD matching globs in $CLEAN_FILES
+# Globals:
+#   CLEAN_FILES
+#   IFS
+#   fileArray
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+findMatchingFiles()
+{
+  local globArray oldIFS
 
-while read file; do
-  [[ ! -n "${file}" ]] && continue
+  [[ -f ${CLEAN_FILES} ]] || error_exit "Could not find file ${CLEAN_FILES}"
 
-  if [[ -f "${file}" ]]; then
-    echo "Removing file ${file} from slug"
-    rm -f ${file}
-  elif [[ -d "${file}" ]]; then
-    echo "Removing directory ${file} from slug"
-    rm -rf ${file}
-  else
-    echo "Location ${file} not found - ignoring"
-  fi
-done <${CLEAN_FILES}
+  status "Finding all matching files and directories in ${CLEAN_FILES}"
+
+  # Temporarily change IFS from all whitespace to newline only
+  oldIFS=$IFS
+  IFS=$'\n'
+
+  # Read globs to an array
+  mapfile -t globArray < ${CLEAN_FILES}
+
+  # Recurse through all matching files/dirs and populate a new array with the result
+  fileArray=()
+  while IFS= read -r -d $'\0'; do
+    fileArray+=("$REPLY")
+  done < <(find ${globArray[*]} -print0)
+
+  # Restore IFS
+  IFS=$oldIFS
+}
+
+#######################################
+# Delete all matching files and directories
+# Globals:
+#   fileArray
+# Arguments:
+#   None
+# Returns:
+#   None
+#######################################
+runRemoval()
+{
+  [[ -z ${fileArray+x} ]] && error_exit "No files or directories to remove from slug"
+
+  status "Removing all matching files and directories from slug"
+  local fileOrDir
+  for fileOrDir in "${fileArray[@]}"; do
+    rm -rf "$fileOrDir"
+    echo "Removed ${fileOrDir} from slug"
+  done
+}
+
+# Run!
+findMatchingFiles
+runRemoval

--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ findMatchingFiles()
 
   [[ -f ${CLEAN_FILES} ]] || error_exit "Could not find file ${CLEAN_FILES}"
 
-  status "Finding all matching files and directories in ${CLEAN_FILES}"
+  status "Finding all files and directories from ${CLEAN_FILES} matching:"
 
   # Temporarily change IFS from all whitespace to newline only
   oldIFS=$IFS
@@ -42,6 +42,11 @@ findMatchingFiles()
 
   # Read globs to an array
   mapfile -t globArray < ${CLEAN_FILES}
+
+  # Output globs
+  printf '%s\n' ${globArray[*]}
+
+  status "Matches not found:"
 
   # Recurse through all matching files/dirs and populate a new array with the result
   fileArray=()
@@ -68,10 +73,12 @@ runRemoval()
 
   status "Removing all matching files and directories from slug"
   local fileOrDir
+
   for fileOrDir in "${fileArray[@]}"; do
     rm -rf "$fileOrDir"
-    echo "Removed ${fileOrDir} from slug"
   done
+
+  echo "Successfully cleaned ${#fileArray[@]} files/directories from slug"
 }
 
 # Run!

--- a/bin/detect
+++ b/bin/detect
@@ -2,17 +2,11 @@
 
 set -euo pipefail
 
-readonly BUILD_DIR=$1
-
-if [[ ! -n "${BUILD_DIR}" ]]; then
-  echo "No build directory specified - exiting"
-  exit 1
-fi
-
-if [[ ! -f "${BUILD_DIR}/.slug-post-clean" ]]; then
+# This pack is valid for apps with a .slug-post-clean in the root
+if [ -f $1/.slug-post-clean ]; then
+  echo "POST BUILD CLEAN"
+  exit 0
+else
   echo "Could not find .slug-post-clean file - exiting"
   exit 1
 fi
-
-echo "POST BUILD CLEAN"
-exit 0

--- a/bin/util/common.sh
+++ b/bin/util/common.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Common helper functions
+
+error_exit()
+{
+  echo "$1 - exiting" 1>&2
+  exit 1
+}
+
+status() {
+  echo "=== $* ==="
+}


### PR DESCRIPTION
# What

The output in our Heroku builds is too chatty, and can be frustrating on slower browsers. This reduces the amount of logs during build; only displaying globs and total number of files/directories deleted.
